### PR TITLE
Exclude build artifacts from package via gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
+build/
 coverage/
 node_modules/


### PR DESCRIPTION
Github issue: https://github.com/kubeflow/frontend/issues/7
Adding `build/` to `.gitignore`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/frontend/43)
<!-- Reviewable:end -->
